### PR TITLE
Save 3D grids in VTK format

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SynchrotronKernel = "7c311715-997f-43ba-a0ee-db1ccfe8d7f2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 Cosmology = "1"

--- a/src/SPHtoGrid.jl
+++ b/src/SPHtoGrid.jl
@@ -33,6 +33,7 @@ include("shared/periodic_mapping.jl")
 include("shared/rotate_particles.jl")
 include("shared/rotate_parameters.jl")
 include("shared/io.jl")
+include("shared/vtk.jl")
 
 # multi-core functionality 
 include("parallel/domain_decomp.jl")
@@ -150,7 +151,8 @@ export mappingParameters,                         # parameters for SPH mapping
     # IO
     read_fits_image,
     read_allsky_fits_image,
-    write_fits_image
+    write_fits_image,
+    write_vtk_image
 
 
 end # module

--- a/src/distributed_mapping/cic.jl
+++ b/src/distributed_mapping/cic.jl
@@ -5,7 +5,8 @@
                         reduce_image::Bool=true,
                         Ndim::Integer=2,
                         snap::Integer=0,
-                        units::String="")
+                        units::String="",
+                        vtk::Bool=true)
 
 Dynamically dispatches workers to compute one cic map per subfile, sum up the results and save to a fits file.
 
@@ -27,7 +28,8 @@ function distributed_cic_map(cic_filename::String, Nsubfiles::Integer,
                              reduce_image::Bool=true,
                              Ndim::Integer=2,
                              snap::Integer=0,
-                             units::String="")
+                             units::String="",
+                             vtk::Bool=true)
 
     println("starting workers")
 
@@ -90,7 +92,14 @@ function distributed_cic_map(cic_filename::String, Nsubfiles::Integer,
 
     println("saving")
     flush(stdout); flush(stderr)
-    write_fits_image(cic_filename, image, param, snap = snap, units = units)
+
+    if Ndim == 3 && vtk
+        # save 3D grid in vtk file format
+        write_vtk_image(cic_filename, image, "map", param, snap = snap, units = units)
+    else
+        # defaults to fits file
+        write_fits_image(cic_filename, image, param, snap = snap, units = units)
+    end
 
     println("Image values")
     println("    Min:    $(minimum(image[.!isnan.(image)]))")

--- a/src/shared/vtk.jl
+++ b/src/shared/vtk.jl
@@ -1,0 +1,22 @@
+using WriteVTK
+
+"""
+    write_vtk_image(filename::String, image::Array{<:Real},
+                    image_name::String, par::mappingParameters;
+                    units::String = "[i.u.]", snap::Integer = 0)
+
+Writes a mapped image to a vti file.
+"""
+function write_vtk_image(filename::String, image::Array{<:Real},
+                        image_name::String, par::mappingParameters;
+                        units::String = "[i.u.]", snap::Integer = 0)
+
+    # construct pixel centers
+    x, y, z = get_map_grid_3D(par)
+
+    vtk_grid(filename, x, y, z) do vtk
+        vtk[image_name] = image  # scalar field attached to points
+        vtk["Units"] = units     # metadata ("field data" in VTK)
+        vtk["Snap"] = snap       # metadata ("field data" in VTK)
+    end
+end


### PR DESCRIPTION
This PR adds the option to save 3D grids in the VTK file format which allows easy usage with ParaView