### PR TITLE
Fix missed particles in 2D

### DIFF
--- a/src/cic_interpolation/cic_2D.jl
+++ b/src/cic_interpolation/cic_2D.jl
@@ -53,7 +53,10 @@ Calculates the kernel- and geometric weights of the pixels a particle contribute
         n_distr_pix = n_tot_pix
 
         # write full particle quantity into the pixel
-        wk[1:n_tot_pix] .= 1.0
+        @inbounds for i = iMin:iMax, j = jMin:jMax
+            idx = calculate_index(i, j, x_pixels)
+            wk[idx] = 1.0
+        end
         
         # the weight is normalized by the pixel area
         if !iszero(distr_area)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -714,6 +714,28 @@ addprocs(2)
             end
         end
     end
+
+    @testset "Bug fixes" begin
+        @testset "Particle not overlapping with centers in 2D" begin
+            kernel = Cubic()
+            npix = 4
+            r = 10
+            param = mappingParameters(; x_lim=[-r, r], y_lim=[-r, r], z_lim=[-r, r], Npixels=npix)
+            pos = Float64[0.5; 0; 0;;]
+            hsms = Float64[1]
+            mass = Float64[1]
+            rho = ones(length(mass))
+            w = part_weight_physical(length(mass), param, 1)
+            map = sphMapping(pos, hsms, mass, rho, rho, w; param=param, kernel, reduce_image=false)
+
+            # check mass conservation
+            mtot = sum(mass)
+
+            Apix = (param.x_lim[2] - param.x_lim[1])^2 / npix^2
+            mmaptot = Apix * sum(map)
+            @test isapprox(mtot, mmaptot; rtol=1e-10)
+        end
+    end
 end
 
 


### PR DESCRIPTION
Previously, just the first n_tot_pix pixels were set to 1, which would usually result in none of the correct pixels being set to 1 and the particle being lost. Instead, now the correct indices are computed and those fields are set to 1.

The newly added test shows a minimal working example of where the previous version failed.